### PR TITLE
feat(slsa): Making SLSA installation optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,21 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
+        slsa: [true, false]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
 
+      - name: Install SLSA verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.0.1
+        if: matrix.slsa && runner.os == 'Linux' # doesn't work on Windows or macOS
+
       - name: Install crane
         uses: ./
 
       - name: Test crane
-        run: |
-          crane version
-          crane ls caddy
-          crane digest nginx:latest
-          crane config alpine:3.11
+        run: crane version
 
   main:
     if: ${{ github.event_name == 'push' }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/IAreKyleW00t/crane-installer/main.yml)](https://github.com/IAreKyleW00t/crane-installer/actions/workflows/main.yml)
 [![License](https://img.shields.io/github/license/IAreKyleW00t/crane-installer)](https://github.com/IAreKyleW00t/crane-installer/blob/main/LICENSE)
 
-This GitHub Action enables you to interacting with remote images and registries using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane). This action will verify the integrity of the `crane` release during installation using [SLSA 3 provenance](https://slsa.dev/) (see notes in [Usage](#usage)).
+This GitHub Action enables you to interacting with remote images and registries using [`crane`](https://github.com/google/go-containerregistry/tree/main/cmd/crane). This action will verify the integrity of the `crane` release during installation if you setup [SLSA 3 provenance](https://slsa.dev/) (see notes and examples below).
 
 For a quick start guide on the usage of `crane`, please refer to https://github.com/google/go-containerregistry/blob/main/cmd/crane/recipes.md. For available crane releases, see https://github.com/google/go-containerregistry/releases.
 
@@ -18,6 +18,7 @@ For a quick start guide on the usage of `crane`, please refer to https://github.
   - [Pinned version](#pinned-version)
   - [Default version](#pinned-version)
   - [Authenicate on other registries](#authenticate-on-other-registries)
+  - [Automatic validation with SLSA](#automatic-validation-with-slsa)
 
 ## Tags
 
@@ -91,6 +92,21 @@ jobs:
           crane auth login docker.io \
             --username "${{ vars.DOCKERHUB_USERNAME }}" \
             --password-stdin
+```
+
+### Automatic validation with SLSA
+
+```yaml
+jobs:
+  crane:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install SLSA verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@v2.0.1
+      - name: Install crane
+        uses: iarekylew00t/crane-installer@v1
+      - name: Check install
+        run: crane version
 ```
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -26,9 +26,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: ${{ runner.os == 'Linux' }}
-      uses: slsa-framework/slsa-verifier/actions/installer@v2.0.1
-
     - shell: bash
       run: |
         #!/bin/bash
@@ -66,12 +63,14 @@ runs:
         curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_${OS}_${ARCH}.tar.gz" > go-containerregistry.tar.gz
 
         # Validate download (Linux only)
-        if [[ "$OS" == "Linux" ]]; then
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl" > provenance.intoto.jsonl
-          slsa-verifier verify-artifact go-containerregistry.tar.gz \
-              --provenance-path provenance.intoto.jsonl \
-              --source-uri github.com/google/go-containerregistry \
-              --source-tag "${VERSION}"
+        if which slsa-verifier >/dev/null; then
+          if [[ "$OS" == "Linux" ]]; then
+            curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/multiple.intoto.jsonl" > provenance.intoto.jsonl
+            slsa-verifier verify-artifact go-containerregistry.tar.gz \
+                --provenance-path provenance.intoto.jsonl \
+                --source-uri github.com/google/go-containerregistry \
+                --source-tag "${VERSION}"
+          fi
         fi
 
         # Install crane


### PR DESCRIPTION
If the user chooses to setup the `slsa-framework/slsa-verifier/actions/installer` before installing this Action, it will validate the binary automatically. Gives the user more control over what is installed on their runner, and if they want to validate things themselves or not.